### PR TITLE
Merge feature "spawnable stacks" into dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 
 /.idea
 
-./foo.mars
+./src/foo.mars

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea
 
 ./src/foo.mars
+foo.mars

--- a/README.md
+++ b/README.md
@@ -109,3 +109,21 @@ ex:
 @my_var 42 def
 my_var print
 ```
+
+### Spawnable Stacks
+
+**Generate a new stack using the "spawn" keyword**
+
+**Switch to that stack using the "switch" keyword**
+
+**Close the stack using the "close" keyword**
+```
+spawn <stack name>
+switch <stack name>
+
+<operations>
+
+close <stack name>
+```
+
+You can list all existing stacks using the "stack" keyword.

--- a/examples/stack_spawning.mars
+++ b/examples/stack_spawning.mars
@@ -1,0 +1,13 @@
+spawn stack_one
+switch stack_one
+    1 2 3 print
+switch main
+    3 2 1 print
+
+@count 1 def
+while count 0 > do
+    switch stack_one print
+    switch main print
+
+    @count count 1 - def
+end

--- a/foo.mars
+++ b/foo.mars
@@ -1,5 +1,0 @@
-@my_var 10 def
-while my_var 0 > do
-    my_var .
-    @my_var my_var 1 - def
-end

--- a/foo.mars
+++ b/foo.mars
@@ -1,0 +1,1 @@
+spawn my_stack

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,16 +9,16 @@ use std::{fs, io, env};
 #[derive(PartialEq)]
 #[derive(Debug)]
 enum OpCodes {
-    PUSH,
+    PUSH, // Begin stack manipulation
     POP,
     PRINT,
     DUP,
     SWAP,
-    ADD,
+    ADD, // Begin arithmetic
     SUB,
     MULT,
     DIV,
-    EQ,
+    EQ, // Begin control flow
     LT,
     GT,
     IF,
@@ -26,12 +26,13 @@ enum OpCodes {
     WHILE,
     END,
     DO,
-    VARDECLARE(String),
+    VARDECLARE(String), // Begin variable declaration
     DEFINE,
-    IDENTIFIER(String),
-    SPAWN(String),
+    IDENTIFIER(String), // Identifier
+    SPAWN(String), // Begin spawnable stacks
     SWITCH(String),
-    CLOSE(String)
+    CLOSE(String),
+    STACKS
 }
 
 #[derive(Debug)]
@@ -54,7 +55,8 @@ enum Instructions {
     While(While),
     SPAWN(String),
     SWITCH(String),
-    CLOSE(String)
+    CLOSE(String),
+    STACKS
 }
 
 #[derive(PartialEq)]
@@ -229,7 +231,8 @@ impl Iterator for Lexer {
                             let name = self.get_next_char_while(token, |c| Self::is_alphanumeric(c));
 
                             return Some(Operation::new(OpCodes::CLOSE(name.to_string()), None));
-                        }
+                        },
+                        "stacks" => return Some(Operation::new(OpCodes::STACKS, None)),
                         _ => return Some(Operation::new(OpCodes::IDENTIFIER(identifier.trim().to_string()), None))
                     }
                 }
@@ -391,6 +394,7 @@ impl Parser {
             OpCodes::SPAWN(name) => Some(Instruction::new(Instructions::SPAWN(name), None)),
             OpCodes::SWITCH(name) => Some(Instruction::new(Instructions::SWITCH(name), None)),
             OpCodes::CLOSE(name) => Some(Instruction::new(Instructions::CLOSE(name), None)),
+            OpCodes::STACKS => Some(Instruction::new(Instructions::STACKS, None))
         }
     }
 }
@@ -589,6 +593,10 @@ impl<'a> Program<'a> {
                     std::process::exit(1);
                 }
                 self.stack_stack.remove(name);
+            },
+            Instructions::STACKS => {
+                println!("Stacks: ");
+                for k in self.stack_stack.keys() {println!("  {}", k)};
             }
         }
     }


### PR DESCRIPTION
Introduce the ability to create your own stacks that you can switch to. It is very important that said stacks are closed, especially down the line when the language becomes more capable of complex things.

Example:
```
spawn <stack name>
switch <stack name>

<operations>

switch main
close <stack name>
```